### PR TITLE
Cst support

### DIFF
--- a/high-level.lisp
+++ b/high-level.lisp
@@ -91,7 +91,7 @@
 
 ;; Parser
 
-(defun parse-string (language string &key (start 0) end)
+(defun parse-string (language string &key (start 0) end produce-cst)
   (let ((parser (ts-parser-new)))
     (when (null-pointer-p parser)
       (error 'cant-create-parser))
@@ -121,7 +121,7 @@
                             (parse-stack '()))
                         (loop
                          (let* ((node (ts-tree-cursor-current-node cursor))
-                                (is-named (ts-node-is-named node)))
+                                (is-named (or produce-cst (ts-node-is-named node))))
                            (cond (did-visit-children
                                   (when is-named
                                     (when (second parse-stack)

--- a/low-level.lisp
+++ b/low-level.lisp
@@ -119,7 +119,7 @@
 ;; Library
 
 (define-foreign-library tree-sitter
-  (t (:default "tree-sitter")))
+  (t (:or (:default "tree-sitter") (:default "libtree-sitter"))))
 
 (use-foreign-library tree-sitter)
 


### PR DESCRIPTION
This MR is to address an issue with a few language modules not providing enough information at the AST-level to determine what an expression is doing. This is remedied by using the full concrete syntax tree. An example of this can be seen with `binary expression` in both the Python and JavaScript language modules. The `right` and `left` fields are returned, but the `binary expression` field also has a field for the operator which is left out with the AST but is avilable with the CST. These changes add a keyword argument to parse the CST instead of just the AST.