### PR TITLE
Allow specifying the foreign function name

### DIFF
--- a/high-level.lisp
+++ b/high-level.lisp
@@ -39,9 +39,10 @@
 (defvar *language-registry*
   (make-hash-table))
 
-(defmacro register-language (name lib)
+(defmacro register-language (name lib &key fn-name)
   (check-type name symbol)
-  (let ((fn-name (substitute #\_ #\- (pathname-name lib)))
+  (check-type fn-name (or null string))
+  (let ((fn-name (or fn-name (substitute #\_ #\- (pathname-name lib))))
         (cffi-name (make-symbol (symbol-name name))))
     `(progn
        (define-foreign-library ,cffi-name


### PR DESCRIPTION
Currently cl-tree-sitter makes the assumption that the library name and the name of the foreign function are always the same, which in our case has turned out not to always be true. This just adds a keyword argument that can be used to specify the foreign function name.