### PR TITLE
Allow users to define where to find tree sitter libraries

### DIFF
--- a/cl-tree-sitter.config.asd
+++ b/cl-tree-sitter.config.asd
@@ -1,0 +1,13 @@
+;;;; +----------------------------------------------------------------+
+;;;; | cl-tree-sitter                                                 |
+;;;; +----------------------------------------------------------------+
+
+(in-package :asdf-user)
+
+(asdf:defsystem #:cl-tree-sitter.config
+  :description "Configure tree-sitter libraries."
+  :author "death <github.com/death>"
+  :license "MIT"
+  :defsystem-depends-on ("asdf-package-system")
+  :components ((:file "config"))
+  :depends-on ("cffi-libffi"))

--- a/config.lisp
+++ b/config.lisp
@@ -1,0 +1,28 @@
+;;;; +----------------------------------------------------------------+
+;;;; | cl-tree-sitter                                                 |
+;;;; +----------------------------------------------------------------+
+
+(defpackage #:cl-tree-sitter.config
+  (:use #:cl)
+  (:import-from #:cffi
+                #:use-foreign-library
+                #:define-foreign-library)
+  (:export
+   #:define-tree-sitter-path
+   #:define-tree-sitter-wrapper-path))
+
+(in-package #:cl-tree-sitter.config)
+
+(defmacro define-tree-sitter-path (path)
+  `(progn
+     (define-foreign-library tree-sitter
+       (t ,path))
+     (use-foreign-library tree-sitter)))
+
+(defmacro define-tree-sitter-wrapper-path (path)
+  `(progn
+     (define-foreign-library tree-sitter-wrapper
+       (t (:default ,path)))
+     (use-foreign-library tree-sitter-wrapper)))
+
+

--- a/low-level.lisp
+++ b/low-level.lisp
@@ -118,18 +118,24 @@
 
 ;; Library
 
-(define-foreign-library tree-sitter
-  (:darwin (:default "/usr/local/lib/libtree-sitter"))
-  (t (:or (:default "tree-sitter") (:default "libtree-sitter"))))
+(handler-case
+    (cffi:foreign-library-loaded-p 'cl-tree-sitter.config::tree-sitter)
+  (t (e)
+    (declare (ignorable e))
+    (define-foreign-library cl-tree-sitter.config::tree-sitter
+      (:darwin (:default "/usr/local/lib/libtree-sitter"))
+      (t (:or (:default "tree-sitter") (:default "libtree-sitter"))))
+    (use-foreign-library cl-tree-sitter.config::tree-sitter-wrapper)))
 
-(use-foreign-library tree-sitter)
-
-(define-foreign-library (tree-sitter-wrapper
-                         :search-path
-                         (asdf:system-relative-pathname :cl-tree-sitter ""))
-  (t (:default "tree-sitter-wrapper")))
-
-(use-foreign-library tree-sitter-wrapper)
+(handler-case
+    (cffi:foreign-library-loaded-p 'cl-tree-sitter.config::tree-sitter-wrapper)
+  (t (e)
+    (declare (ignorable e))
+    (define-foreign-library (cl-tree-sitter.config::tree-sitter-wrapper
+                             :search-path
+                             (asdf:system-relative-pathname :cl-tree-sitter ""))
+      (t (:default "tree-sitter-wrapper")))
+    (use-foreign-library cl-tree-sitter.config::tree-sitter-wrapper)))
 
 ;; Types
 


### PR DESCRIPTION
This helps in case packages are installed on non-standard places (e.g. using nix).

This is an example of how to glue things together:

```lisp
(push "../cl-tree-sitter/" ql:*local-project-directories*)
(push *default-pathname-defaults* ql:*local-project-directories*)

(ql:quickload :cl-tree-sitter.config)

(cl-tree-sitter.config:define-tree-sitter-path "/nix/store/jkmvpg3d3mvj72qmzdwipf01bx4kgxi9-tree-sitter-0.20.8/lib/libtree-sitter.dylib")
(cl-tree-sitter.config:define-tree-sitter-wrapper-path "./cl-tree-sitter/tree-sitter-wrapper.so")

(ql:quickload :cl-tree-sitter)

(cl-tree-sitter:register-language :kotlin
                                  "./tree-sitter-kotlin/libtree-sitter-kotlin"
                                  :fn-name "tree_sitter_kotlin")

(cl-tree-sitter:parse-string :kotlin "fun a() {}")
```