### PR TITLE
Compile dynamic library for macOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.so
 *.so.*
+*.dylib
+*.dylib.*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
+CC ?= cc
+
 PKG_CONFIG=$(shell command -v pkg-config)
+
+OS = $(shell uname -o)
+
+ifeq ($(OS), Darwin)
+SOEXT = .dylib
+DYNFLAG= -dynamiclib
+else
+SOEXT = .so
+DYNFLAG= -shared
+endif
 
 ifneq ("$(PKG_CONFIG)", "")
 # the ?= will only compute the RHS if the variable
@@ -7,16 +19,16 @@ TREE_SITTER_INCLUDE ?= $(shell $(PKG_CONFIG) --cflags tree-sitter)
 TREE_SITTER_LIB ?= $(shell $(PKG_CONFIG) --libs tree-sitter)
 endif
 
-CFLAGS = -g -O2 -Wall -Wno-unused-value -fPIC -shared
+CFLAGS = -g -O2 -Wall -Wno-unused-value -fPIC $(DYNFLAG)
 CFLAGS+= $(TREE_SITTER_INCLUDE)
 LDFLAGS = $(TREE_SITTER_LIB)
 FILE = tree-sitter-wrapper.c
-SO = tree-sitter-wrapper.so
+SO = tree-sitter-wrapper$(SOEXT)
 
 all: $(SO)
 
 $(SO): $(FILE)
-	cc $(CFLAGS) $(FILE) -o $(SO) $(LDFLAGS)
+	$(CC) $(CFLAGS) $(FILE) -o $(SO) $(LDFLAGS)
 
 clean:
 	-rm $(SO)


### PR DESCRIPTION
The `:default` option on `define-foreign-library` will add the extension according to the host OS.

Tested on macOS with `CC=clang make all`.