### PR TITLE
auto remove lib from treesitter language libraries

### DIFF
--- a/high-level.lisp
+++ b/high-level.lisp
@@ -51,6 +51,7 @@
         string))) ; If the substring is not found, return the original string
 
 (defmacro register-language (name lib &key fn-name)
+  ; Need to check and see if .so extension is added to lib, if so then remove it
   (check-type name symbol)
   (check-type fn-name (or null string))
   (let ((fn-name (or fn-name (remove-first-substring 


### PR DESCRIPTION
this package crashes when register language is called on a tree-sitter language shared library with the prefix lib. This can be avoided if the fn-name keyword parameter is used to pass a name for the ffi caller to use. Since every ts library built from source will have a lib prefix, I think that it should be checked for an removed automatically.